### PR TITLE
Add an empty node case

### DIFF
--- a/src/__test__/index.test.js
+++ b/src/__test__/index.test.js
@@ -10,3 +10,7 @@ test("mrk can throw an error when passed a function", () => {
 test("mrk can get some basic markdown", () => {
   expect(mrk("# Hello").get()).toBe("# Hello");
 });
+
+test("mrk can take nothing", () => {
+  expect(mrk().type()).toBe("root");
+});

--- a/src/__test__/set.test.js
+++ b/src/__test__/set.test.js
@@ -1,4 +1,5 @@
 const { base } = require("./testHelper.js");
+const mrk = require("../index.js");
 
 // Set
 describe("set function", () => {
@@ -9,5 +10,15 @@ describe("set function", () => {
   test("it can set a header", () => {
     const title = "yes, hello, I am title";
     expect(base.heading().set(title).value()).toBe(title);
+  });
+
+  test("it can set something after recieving nothing", () => {
+    expect(mrk().set("Hey").getAll()).toBe("Hey");
+  });
+
+  test("it can override something", () => {
+    expect(mrk().set("first").paragraph().set("second").getAll()).toBe(
+      "second"
+    );
   });
 });


### PR DESCRIPTION
Allows empty node behavior:

``` js
mrk().set("some markdown") // Does not error
```